### PR TITLE
Checkout breaking change

### DIFF
--- a/.github/templates/README.tpl
+++ b/.github/templates/README.tpl
@@ -21,6 +21,19 @@ version 0.11+ and 0.12+ but may work for others.)
 | --- |
 {{- end }}
 
+### Upgrade v0 to v1
+
+Release v1 contains following breaking changes:
+
+- default value of `output-file` has been changed to `README.md`
+- default value of `template` has been changed to
+
+  ```text
+  <!-- BEGIN_TF_DOCS -->
+  {{"{{"}} .Content {{"}}"}}
+  <!-- END_TF_DOCS -->
+  ```
+
 ## Usage
 
 To use terraform-docs github action, configure a YAML workflow file, e.g.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - release-*
   pull_request:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -8,8 +8,21 @@ branch.
 
 ## Version
 
-`v0.11.0` (uses [terraform-docs] v0.16.0, which is supported and tested on Terraform
+`v1.0.0` (uses [terraform-docs] v0.16.0, which is supported and tested on Terraform
 version 0.11+ and 0.12+ but may work for others.)
+
+### Upgrade v0 to v1
+
+Release v1 contains following breaking changes:
+
+- default value of `output-file` has been changed to `README.md`
+- default value of `template` has been changed to
+
+  ```text
+  <!-- BEGIN_TF_DOCS -->
+  {{ .Content }}
+  <!-- END_TF_DOCS -->
+  ```
 
 ## Usage
 
@@ -29,7 +42,7 @@ jobs:
         ref: ${{ github.event.pull_request.head.ref }}
 
     - name: Render terraform docs inside the README.md and push changes back to PR branch
-      uses: terraform-docs/gh-actions@v0.11.0
+      uses: terraform-docs/gh-actions@v1.0.0
       with:
         working-dir: .
         output-file: README.md
@@ -134,7 +147,7 @@ To enable you need to ensure a few things first:
 
 ```yaml
 - name: Generate TF Docs
-  uses: terraform-docs/gh-actions@v0.11.0
+  uses: terraform-docs/gh-actions@v1.0.0
   with:
     working-dir: .
 ```
@@ -143,7 +156,7 @@ To enable you need to ensure a few things first:
 
 ```yaml
 - name: Generate TF Docs
-  uses: terraform-docs/gh-actions@v0.11.0
+  uses: terraform-docs/gh-actions@v1.0.0
   with:
     working-dir: .,example1,example3/modules/test
 ```
@@ -152,7 +165,7 @@ To enable you need to ensure a few things first:
 
 ```yaml
 - name: Generate TF docs
-  uses: terraform-docs/gh-actions@v0.11.0
+  uses: terraform-docs/gh-actions@v1.0.0
   with:
     atlantis-file: atlantis.yaml
 ```
@@ -161,7 +174,7 @@ To enable you need to ensure a few things first:
 
 ```yaml
 - name: Generate TF docs
-  uses: terraform-docs/gh-actions@v0.11.0
+  uses: terraform-docs/gh-actions@v1.0.0
   with:
     find-dir: examples/
 ```
@@ -170,13 +183,13 @@ To enable you need to ensure a few things first:
 
 ```yaml
 - name: Generate TF docs
-  uses: terraform-docs/gh-actions@v0.11.0
+  uses: terraform-docs/gh-actions@v1.0.0
   with:
     working-dir: examples/
     recursive: true
     recursive-path: modules
 ```
 
-Complete examples can be found [here](https://github.com/terraform-docs/gh-actions/tree/v0.11.0/examples).
+Complete examples can be found [here](https://github.com/terraform-docs/gh-actions/tree/v1.0.0/examples).
 
 [terraform-docs]: https://github.com/terraform-docs/terraform-docs

--- a/src/docker-entrypoint.sh
+++ b/src/docker-entrypoint.sh
@@ -21,20 +21,6 @@ set -o errtrace
 # shellcheck disable=SC2206
 cmd_args=(${INPUT_OUTPUT_FORMAT})
 
-# shellcheck disable=SC2206
-cmd_args+=(${INPUT_ARGS})
-
-if [ "${INPUT_CONFIG_FILE}" = "disabled" ]; then
-    case "$INPUT_OUTPUT_FORMAT" in
-    "asciidoc" | "asciidoc table" | "asciidoc document")
-        cmd_args+=(--indent "${INPUT_INDENTION}")
-        ;;
-
-    "markdown" | "markdown table" | "markdown document")
-        cmd_args+=(--indent "${INPUT_INDENTION}")
-        ;;
-    esac
-
     if [ -z "${INPUT_TEMPLATE}" ]; then
         INPUT_TEMPLATE=$(printf '<!-- BEGIN_TF_DOCS -->\n{{ .Content }}\n<!-- END_TF_DOCS -->')
     fi
@@ -52,6 +38,11 @@ git_setup() {
     git config --global user.name "${INPUT_GIT_PUSH_USER_NAME}"
     git config --global user.email "${INPUT_GIT_PUSH_USER_EMAIL}"
     git fetch --depth=1 origin +refs/tags/*:refs/tags/* || true
+
+    # When the runner maps the $GITHUB_WORKSPACE mount, it is owned by the runner user,
+    # while the created folders are owned by the container user, causing this error.
+    # Issue description here: https://github.com/actions/checkout/issues/766
+    git config --global --add safe.directory "$GITHUB_WORKSPACE"
 }
 
 git_add() {

--- a/src/docker-entrypoint.sh
+++ b/src/docker-entrypoint.sh
@@ -18,8 +18,23 @@ set -o errexit
 set -o pipefail
 set -o errtrace
 
+set -x
 # shellcheck disable=SC2206
 cmd_args=(${INPUT_OUTPUT_FORMAT})
+
+# shellcheck disable=SC2206
+cmd_args+=(${INPUT_ARGS})
+
+if [ "${INPUT_CONFIG_FILE}" = "disabled" ]; then
+    case "$INPUT_OUTPUT_FORMAT" in
+    "asciidoc" | "asciidoc table" | "asciidoc document")
+        cmd_args+=(--indent "${INPUT_INDENTION}")
+        ;;
+
+    "markdown" | "markdown table" | "markdown document")
+        cmd_args+=(--indent "${INPUT_INDENTION}")
+        ;;
+    esac
 
     if [ -z "${INPUT_TEMPLATE}" ]; then
         INPUT_TEMPLATE=$(printf '<!-- BEGIN_TF_DOCS -->\n{{ .Content }}\n<!-- END_TF_DOCS -->')
@@ -38,7 +53,6 @@ git_setup() {
     git config --global user.name "${INPUT_GIT_PUSH_USER_NAME}"
     git config --global user.email "${INPUT_GIT_PUSH_USER_EMAIL}"
     git fetch --depth=1 origin +refs/tags/*:refs/tags/* || true
-
     # When the runner maps the $GITHUB_WORKSPACE mount, it is owned by the runner user,
     # while the created folders are owned by the container user, causing this error.
     # Issue description here: https://github.com/actions/checkout/issues/766
@@ -174,5 +188,5 @@ else
         exit 1
     fi
 fi
-
+set +x
 exit 0


### PR DESCRIPTION
fixing git breaking change, described here: https://github.com/actions/checkout/issues/766
Attempts to use git calls in an action where the user on the folder doesn't match the current user will fail. This comes about because of the way GitHub Actions mounts the $GITHUB_WORKSPACE directory on the parent container filesystem. Global setting introduced as workaround, this fix applies the setting.

